### PR TITLE
Strip unset elements from paths

### DIFF
--- a/src/grph/path/SearchResultWrappedPath.java
+++ b/src/grph/path/SearchResultWrappedPath.java
@@ -108,6 +108,7 @@ public class SearchResultWrappedPath extends AbstractPath
 			}
 
 			s.add(source);
+			s.trim();
 			this.vertexArray = s.elements();
 			Arrays.reverse(this.vertexArray);
 		}


### PR DESCRIPTION
Paths like shortest paths may be padded with "0" entries in the front if the path's length doesn't match the length of the internal array.
Trimming the list before retrieving the internal array eliminates those additional entries.
This should have better performance than letting the end-user distinguish padding-entries from intended entries referring to node "0".